### PR TITLE
3주차 과제구현

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -14,5 +14,18 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="community@localhost" uuid="0dc4c300-6dac-48ad-bf3f-d1ae1aa0205b">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/community</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -2,10 +2,12 @@ package org.sopt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class Main {
 	public static void main(String[] args) {
 		SpringApplication.run(Main.class, args);

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -3,6 +3,7 @@ package org.sopt.controller;
 import java.util.List;
 
 import org.sopt.dto.PostCreateRequest;
+import org.sopt.dto.PostDetailResponse;
 import org.sopt.dto.PostResponse;
 import org.sopt.dto.PostUpdateRequest;
 import org.sopt.global.common.dto.ResponseDto;
@@ -38,7 +39,7 @@ public class PostController {
 	}
 
 	@GetMapping("/posts/{id}")
-	public ResponseDto<PostResponse> getPostById(@PathVariable int id) {
+	public ResponseDto<PostDetailResponse> getPostById(@PathVariable int id) {
 		return ResponseDto.ok(postService.getPostById(id));
 	}
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -33,7 +33,7 @@ public class PostController {
 	}
 
 	@GetMapping("/posts")
-	public ResponseDto<List<PostResponse>> getAllPosts() {
+	public ResponseDto<List<PostResponse>> getAllPosts(@RequestHeader int asdf) {
 		return ResponseDto.ok(postService.getAllPost());
 	}
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -33,7 +33,7 @@ public class PostController {
 	}
 
 	@GetMapping("/posts")
-	public ResponseDto<List<PostResponse>> getAllPosts(@RequestHeader int asdf) {
+	public ResponseDto<List<PostResponse>> getAllPosts() {
 		return ResponseDto.ok(postService.getAllPost());
 	}
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -45,14 +45,15 @@ public class PostController {
 	}
 
 	@DeleteMapping("/posts/{id}")
-	public ResponseDto<Void> deletePostById(@PathVariable int id) {
-		postService.deletePostById(id);
+	public ResponseDto<Void> deletePostById(@RequestHeader Integer userId, @PathVariable int id) {
+		postService.deletePostById(userId, id);
 		return ResponseDto.okWithoutContent();
 	}
 
 	@PutMapping("/posts/{id}")
-	public ResponseDto<Void> updatePost(@PathVariable int id, @RequestBody PostUpdateRequest request) {
-		postService.updatePost(id, request);
+	public ResponseDto<Void> updatePost(@RequestHeader Integer userId, @PathVariable int id,
+		@RequestBody PostUpdateRequest request) {
+		postService.updatePost(userId, id, request);
 		return ResponseDto.okWithoutContent();
 	}
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,8 +26,9 @@ public class PostController {
 	}
 
 	@PostMapping("/posts")
-	public ResponseDto<PostResponse> createPost(@RequestBody PostCreateRequest postCreateRequest) {
-		PostResponse response = postService.createPost(postCreateRequest);
+	public ResponseDto<PostResponse> createPost(@RequestHeader Integer userId,
+		@RequestBody PostCreateRequest postCreateRequest) {
+		PostResponse response = postService.createPost(userId, postCreateRequest);
 		return ResponseDto.created(response);
 	}
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -2,6 +2,7 @@ package org.sopt.controller;
 
 import java.util.List;
 
+import org.sopt.domain.constant.Tag;
 import org.sopt.dto.PostCreateRequest;
 import org.sopt.dto.PostDetailResponse;
 import org.sopt.dto.PostResponse;
@@ -56,8 +57,9 @@ public class PostController {
 	}
 
 	@GetMapping("/posts/search")
-	public ResponseDto<List<PostResponse>> search(@RequestParam String keyword) {
-		List<PostResponse> postResponses = postService.searchPost(keyword);
+	public ResponseDto<List<PostResponse>> search(@RequestParam(required = false) String keyword,
+		@RequestParam(required = false) Tag tag) {
+		List<PostResponse> postResponses = postService.searchPost(keyword, tag);
 		return ResponseDto.ok(postResponses);
 	}
 }

--- a/src/main/java/org/sopt/controller/UserController.java
+++ b/src/main/java/org/sopt/controller/UserController.java
@@ -1,0 +1,26 @@
+package org.sopt.controller;
+
+import org.sopt.dto.UserCreateRequest;
+import org.sopt.dto.UserResponse;
+import org.sopt.global.common.dto.ResponseDto;
+import org.sopt.service.UserService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+	private final UserService userService;
+
+	public UserController(UserService userService) {
+		this.userService = userService;
+	}
+
+	@PostMapping
+	public ResponseDto<UserResponse> create(@RequestBody UserCreateRequest dto) {
+		UserResponse response = userService.createUser(dto);
+		return ResponseDto.created(response);
+	}
+}

--- a/src/main/java/org/sopt/domain/Content.java
+++ b/src/main/java/org/sopt/domain/Content.java
@@ -1,0 +1,11 @@
+package org.sopt.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record Content(
+	@Column(nullable = false)
+	String value
+) {
+}

--- a/src/main/java/org/sopt/domain/Content.java
+++ b/src/main/java/org/sopt/domain/Content.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public record Content(
-	@Column(nullable = false)
+	@Column(name = "content", nullable = false)
 	String value
 ) {
 	public Content {

--- a/src/main/java/org/sopt/domain/Content.java
+++ b/src/main/java/org/sopt/domain/Content.java
@@ -1,5 +1,7 @@
 package org.sopt.domain;
 
+import static org.sopt.util.ContentFormatValidateUtil.*;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
@@ -8,4 +10,8 @@ public record Content(
 	@Column(nullable = false)
 	String value
 ) {
+	public Content {
+		validateContentFormat(value);
+	}
 }
+

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -12,9 +12,13 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@Table(name = "posts")
 public class Post {
 
 	@Id
@@ -27,12 +31,20 @@ public class Post {
 	@Embedded
 	private Title title;
 
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	private Post(Title title, User user) {
+		this.title = title;
+		this.user = user;
+	}
+
 	private Post(Title title) {
 		this.title = title;
 	}
 
-	public Post() {
-
+	protected Post() {
 	}
 
 	public static Post create(Title title) {

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -71,7 +71,7 @@ public class Post {
 		return this.id;
 	}
 
-	public String getTitleContent() {
+	public String getTitle() {
 		return this.title.content();
 	}
 
@@ -79,8 +79,8 @@ public class Post {
 		return user;
 	}
 
-	public Content getContent() {
-		return content;
+	public String getContent() {
+		return content.value();
 	}
 
 	public LocalDateTime getCreatedAt() {

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -60,8 +60,9 @@ public class Post {
 		return new Post(title, content);
 	}
 
-	public void updatePost(String title) {
+	public void updatePost(String title, String content) {
 		this.title = new Title(title);
+		this.content = new Content(content);
 	}
 
 	public int getId() {

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -51,20 +51,24 @@ public class Post {
 		return new Post(title);
 	}
 
+	public void updatePost(String title) {
+		this.title = new Title(title);
+	}
+
 	public int getId() {
 		return this.id;
 	}
 
 	public String getTitleContent() {
-		return this.title.getContent();
+		return this.title.content();
+	}
+
+	public User getUser() {
+		return user;
 	}
 
 	public LocalDateTime getCreatedAt() {
 		return createdAt;
-	}
-
-	public void updatePost(String title) {
-		this.title = new Title(title);
 	}
 
 	@Override
@@ -84,14 +88,5 @@ public class Post {
 	@Override
 	public int hashCode() {
 		return Objects.hash(id, title, createdAt);
-	}
-
-	@Override
-	public String toString() {
-		return "Post{" +
-			"id=" + id +
-			", title='" + title + '\'' +
-			", createdAt=" + createdAt +
-			'}';
 	}
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -3,12 +3,15 @@ package org.sopt.domain;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import org.sopt.domain.constant.Tag;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,15 +41,20 @@ public class Post {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	private Post(Title title, User user, Content content) {
+	@Enumerated(value = EnumType.STRING)
+	private Tag tag;
+
+	private Post(Title title, User user, Content content, Tag tag) {
 		this.title = title;
 		this.user = user;
 		this.content = content;
+		this.tag = tag;
 	}
 
-	private Post(Title title, Content content) {
+	private Post(Title title, Content content, Tag tag) {
 		this.title = title;
 		this.content = content;
+		this.tag = tag;
 	}
 
 	private Post(Title title) {
@@ -56,8 +64,8 @@ public class Post {
 	protected Post() {
 	}
 
-	public static Post create(Title title, Content content) {
-		return new Post(title, content);
+	public static Post create(Title title, Content content, Tag tag) {
+		return new Post(title, content, tag);
 	}
 
 	public void updatePost(String title, String content) {
@@ -85,6 +93,10 @@ public class Post {
 		return createdAt;
 	}
 
+	public Tag getTag() {
+		return tag;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -103,5 +115,4 @@ public class Post {
 	public int hashCode() {
 		return Objects.hash(id, title, createdAt);
 	}
-
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -31,13 +31,22 @@ public class Post {
 	@Embedded
 	private Title title;
 
+	@Embedded
+	private Content content;
+
 	@ManyToOne
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	private Post(Title title, User user) {
+	private Post(Title title, User user, Content content) {
 		this.title = title;
 		this.user = user;
+		this.content = content;
+	}
+
+	private Post(Title title, Content content) {
+		this.title = title;
+		this.content = content;
 	}
 
 	private Post(Title title) {
@@ -47,8 +56,8 @@ public class Post {
 	protected Post() {
 	}
 
-	public static Post create(Title title) {
-		return new Post(title);
+	public static Post create(Title title, Content content) {
+		return new Post(title, content);
 	}
 
 	public void updatePost(String title) {
@@ -65,6 +74,10 @@ public class Post {
 
 	public User getUser() {
 		return user;
+	}
+
+	public Content getContent() {
+		return content;
 	}
 
 	public LocalDateTime getCreatedAt() {
@@ -89,4 +102,5 @@ public class Post {
 	public int hashCode() {
 		return Objects.hash(id, title, createdAt);
 	}
+
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -44,15 +44,9 @@ public class Post {
 	@Enumerated(value = EnumType.STRING)
 	private Tag tag;
 
-	private Post(Title title, User user, Content content, Tag tag) {
+	private Post(Title title, Content content, Tag tag, User user) {
 		this.title = title;
 		this.user = user;
-		this.content = content;
-		this.tag = tag;
-	}
-
-	private Post(Title title, Content content, Tag tag) {
-		this.title = title;
 		this.content = content;
 		this.tag = tag;
 	}
@@ -64,8 +58,8 @@ public class Post {
 	protected Post() {
 	}
 
-	public static Post create(Title title, Content content, Tag tag) {
-		return new Post(title, content, tag);
+	public static Post create(Title title, Content content, Tag tag, User user) {
+		return new Post(title, content, tag, user);
 	}
 
 	public void updatePost(String title, String content) {

--- a/src/main/java/org/sopt/domain/Title.java
+++ b/src/main/java/org/sopt/domain/Title.java
@@ -2,44 +2,16 @@ package org.sopt.domain;
 
 import static org.sopt.util.TitleFormatValidateUtil.*;
 
-import java.util.Objects;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
-public class Title {
-
+public record Title(
 	@Column(nullable = false)
-	private String content;
-
-	public Title(String content) {
+	String content
+) {
+	public Title {
 		validate(content);
-		this.content = content;
-	}
-
-	public Title() {
-	}
-
-	public String getContent() {
-		return content;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		Title title = (Title)o;
-		return Objects.equals(content, title.content);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(content);
 	}
 
 	@Override

--- a/src/main/java/org/sopt/domain/Title.java
+++ b/src/main/java/org/sopt/domain/Title.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public record Title(
-	@Column(nullable = false)
+	@Column(name = "title", nullable = false)
 	String content
 ) {
 	public Title {

--- a/src/main/java/org/sopt/domain/Title.java
+++ b/src/main/java/org/sopt/domain/Title.java
@@ -11,7 +11,7 @@ public record Title(
 	String content
 ) {
 	public Title {
-		validate(content);
+		validateTitleFormat(content);
 	}
 
 	@Override

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -1,0 +1,41 @@
+package org.sopt.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
+	private String name;
+	private String email;
+
+	protected User() {
+	}
+
+	private User(String name, String email) {
+		this.name = name;
+		this.email = email;
+	}
+
+	public static User createUser(String name, String email) {
+		return new User(name, email);
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+}

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -23,7 +23,7 @@ public class User {
 		this.email = email;
 	}
 
-	public static User createUser(String name, String email) {
+	public static User create(String name, String email) {
 		return new User(name, email);
 	}
 

--- a/src/main/java/org/sopt/domain/constant/Tag.java
+++ b/src/main/java/org/sopt/domain/constant/Tag.java
@@ -1,0 +1,6 @@
+package org.sopt.domain.constant;
+
+public enum Tag {
+	BE, INFRA, DB
+	
+}

--- a/src/main/java/org/sopt/domain/constant/Tag.java
+++ b/src/main/java/org/sopt/domain/constant/Tag.java
@@ -1,6 +1,19 @@
 package org.sopt.domain.constant;
 
+import org.sopt.exception.InvalidTagException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum Tag {
-	BE, INFRA, DB
-	
+	BE, INFRA, DB;
+
+	@JsonCreator
+	public static Tag fromString(String value) {
+		for (Tag tag : Tag.values()) {
+			if (tag.name().equalsIgnoreCase(value)) {
+				return tag;
+			}
+		}
+		throw new InvalidTagException();
+	}
 }

--- a/src/main/java/org/sopt/dto/PostCreateRequest.java
+++ b/src/main/java/org/sopt/dto/PostCreateRequest.java
@@ -2,15 +2,10 @@ package org.sopt.dto;
 
 import static org.sopt.util.TitleFormatValidateUtil.*;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+public record PostCreateRequest(String title, String content) {
 
-public record PostCreateRequest(String title) {
-
-	@JsonCreator
-	public PostCreateRequest(@JsonProperty("title") String title) {
-		validate(title);
-		this.title = title;
+	public PostCreateRequest {
+		validateTitleFormat(title);
 	}
 }
 

--- a/src/main/java/org/sopt/dto/PostCreateRequest.java
+++ b/src/main/java/org/sopt/dto/PostCreateRequest.java
@@ -1,5 +1,6 @@
 package org.sopt.dto;
 
+import static org.sopt.util.ContentFormatValidateUtil.*;
 import static org.sopt.util.TitleFormatValidateUtil.*;
 
 import org.sopt.domain.constant.Tag;
@@ -8,6 +9,7 @@ public record PostCreateRequest(String title, String content, Tag tag) {
 
 	public PostCreateRequest {
 		validateTitleFormat(title);
+		validateContentFormat(content);
 	}
 }
 

--- a/src/main/java/org/sopt/dto/PostCreateRequest.java
+++ b/src/main/java/org/sopt/dto/PostCreateRequest.java
@@ -2,7 +2,9 @@ package org.sopt.dto;
 
 import static org.sopt.util.TitleFormatValidateUtil.*;
 
-public record PostCreateRequest(String title, String content) {
+import org.sopt.domain.constant.Tag;
+
+public record PostCreateRequest(String title, String content, Tag tag) {
 
 	public PostCreateRequest {
 		validateTitleFormat(title);

--- a/src/main/java/org/sopt/dto/PostDetailResponse.java
+++ b/src/main/java/org/sopt/dto/PostDetailResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.dto;
+
+import org.sopt.domain.Post;
+
+public record PostDetailResponse(
+	String title,
+	String content,
+	String username
+) {
+	public static PostDetailResponse from(Post post) {
+		return new PostDetailResponse(
+			post.getTitle(),
+			post.getContent(),
+			post.getUser().getName()
+		);
+	}
+}

--- a/src/main/java/org/sopt/dto/PostResponse.java
+++ b/src/main/java/org/sopt/dto/PostResponse.java
@@ -3,11 +3,13 @@ package org.sopt.dto;
 import org.sopt.domain.Post;
 
 public record PostResponse(
-	String title
+	String title,
+	String username
 ) {
 	public static PostResponse from(Post post) {
 		return new PostResponse(
-			post.getTitleContent()
+			post.getTitle(),
+			post.getUser().getName()
 		);
 	}
 }

--- a/src/main/java/org/sopt/dto/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/dto/PostUpdateRequest.java
@@ -2,14 +2,9 @@ package org.sopt.dto;
 
 import static org.sopt.util.TitleFormatValidateUtil.*;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+public record PostUpdateRequest(String title, String content) {
 
-public record PostUpdateRequest(String title) {
-	@JsonCreator
-	public PostUpdateRequest(@JsonProperty("title") String title) {
+	public PostUpdateRequest {
 		validateTitleFormat(title);
-		this.title = title;
 	}
-
 }

--- a/src/main/java/org/sopt/dto/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/dto/PostUpdateRequest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record PostUpdateRequest(String title) {
 	@JsonCreator
 	public PostUpdateRequest(@JsonProperty("title") String title) {
-		validate(title);
+		validateTitleFormat(title);
 		this.title = title;
 	}
 

--- a/src/main/java/org/sopt/dto/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/dto/PostUpdateRequest.java
@@ -1,10 +1,12 @@
 package org.sopt.dto;
 
+import static org.sopt.util.ContentFormatValidateUtil.*;
 import static org.sopt.util.TitleFormatValidateUtil.*;
 
 public record PostUpdateRequest(String title, String content) {
 
 	public PostUpdateRequest {
 		validateTitleFormat(title);
+		validateContentFormat(content);
 	}
 }

--- a/src/main/java/org/sopt/dto/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/dto/PostUpdateRequest.java
@@ -3,7 +3,9 @@ package org.sopt.dto;
 import static org.sopt.util.ContentFormatValidateUtil.*;
 import static org.sopt.util.TitleFormatValidateUtil.*;
 
-public record PostUpdateRequest(String title, String content) {
+import org.sopt.domain.constant.Tag;
+
+public record PostUpdateRequest(String title, String content, Tag tag) {
 
 	public PostUpdateRequest {
 		validateTitleFormat(title);

--- a/src/main/java/org/sopt/dto/UserCreateRequest.java
+++ b/src/main/java/org/sopt/dto/UserCreateRequest.java
@@ -1,7 +1,12 @@
 package org.sopt.dto;
 
+import static org.sopt.util.EmailValidator.*;
+
 public record UserCreateRequest(
 	String name,
 	String email
 ) {
+	public UserCreateRequest {
+		validate(name, email);
+	}
 }

--- a/src/main/java/org/sopt/dto/UserCreateRequest.java
+++ b/src/main/java/org/sopt/dto/UserCreateRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.dto;
+
+public record UserCreateRequest(
+	String name,
+	String email
+) {
+}

--- a/src/main/java/org/sopt/dto/UserResponse.java
+++ b/src/main/java/org/sopt/dto/UserResponse.java
@@ -1,10 +1,11 @@
 package org.sopt.dto;
 
 public record UserResponse(
+	long userId,
 	String name,
 	String email
 ) {
-	public static UserResponse of(String name, String email) {
-		return new UserResponse(name, email);
+	public static UserResponse of(long userId, String name, String email) {
+		return new UserResponse(userId, name, email);
 	}
 }

--- a/src/main/java/org/sopt/dto/UserResponse.java
+++ b/src/main/java/org/sopt/dto/UserResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.dto;
+
+public record UserResponse(
+	String name,
+	String email
+) {
+	public static UserResponse of(String name, String email) {
+		return new UserResponse(name, email);
+	}
+}

--- a/src/main/java/org/sopt/exception/AccessDeniedException.java
+++ b/src/main/java/org/sopt/exception/AccessDeniedException.java
@@ -1,0 +1,11 @@
+package org.sopt.exception;
+
+import static org.sopt.global.config.exception.constant.ExceptionCode.*;
+
+import org.sopt.global.config.exception.BusinessException;
+
+public class AccessDeniedException extends BusinessException {
+	public AccessDeniedException() {
+		super(ACCESS_DENIED);
+	}
+}

--- a/src/main/java/org/sopt/exception/ContentEmptyException.java
+++ b/src/main/java/org/sopt/exception/ContentEmptyException.java
@@ -1,0 +1,10 @@
+package org.sopt.exception;
+
+import org.sopt.global.config.exception.BusinessException;
+import org.sopt.global.config.exception.constant.ExceptionCode;
+
+public class ContentEmptyException extends BusinessException {
+	public ContentEmptyException() {
+		super(ExceptionCode.EMPTY_CONTENT);
+	}
+}

--- a/src/main/java/org/sopt/exception/ContentLengthException.java
+++ b/src/main/java/org/sopt/exception/ContentLengthException.java
@@ -1,0 +1,10 @@
+package org.sopt.exception;
+
+import org.sopt.global.config.exception.BusinessException;
+import org.sopt.global.config.exception.constant.ExceptionCode;
+
+public class ContentLengthException extends BusinessException {
+	public ContentLengthException() {
+		super(ExceptionCode.CONTENT_TOO_LONG);
+	}
+}

--- a/src/main/java/org/sopt/exception/InvalidEmailFormatException.java
+++ b/src/main/java/org/sopt/exception/InvalidEmailFormatException.java
@@ -1,0 +1,10 @@
+package org.sopt.exception;
+
+import org.sopt.global.config.exception.BusinessException;
+import org.sopt.global.config.exception.constant.ExceptionCode;
+
+public class InvalidEmailFormatException extends BusinessException {
+	public InvalidEmailFormatException() {
+		super(ExceptionCode.INVALID_EMAIL_FORMAT);
+	}
+}

--- a/src/main/java/org/sopt/exception/InvalidTagException.java
+++ b/src/main/java/org/sopt/exception/InvalidTagException.java
@@ -1,0 +1,11 @@
+package org.sopt.exception;
+
+import static org.sopt.global.config.exception.constant.ExceptionCode.*;
+
+import org.sopt.global.config.exception.BusinessException;
+
+public class InvalidTagException extends BusinessException {
+	public InvalidTagException() {
+		super(INVALID_TAG);
+	}
+}

--- a/src/main/java/org/sopt/exception/NameEmptyException.java
+++ b/src/main/java/org/sopt/exception/NameEmptyException.java
@@ -1,0 +1,10 @@
+package org.sopt.exception;
+
+import org.sopt.global.config.exception.BusinessException;
+import org.sopt.global.config.exception.constant.ExceptionCode;
+
+public class NameEmptyException extends BusinessException {
+	public NameEmptyException() {
+		super(ExceptionCode.EMPTY_NAME);
+	}
+}

--- a/src/main/java/org/sopt/exception/NameLengthException.java
+++ b/src/main/java/org/sopt/exception/NameLengthException.java
@@ -1,0 +1,11 @@
+package org.sopt.exception;
+
+import static org.sopt.global.config.exception.constant.ExceptionCode.*;
+
+import org.sopt.global.config.exception.BusinessException;
+
+public class NameLengthException extends BusinessException {
+	public NameLengthException() {
+		super(NAME_TOO_LONG);
+	}
+}

--- a/src/main/java/org/sopt/exception/UserNotFoundException.java
+++ b/src/main/java/org/sopt/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package org.sopt.exception;
+
+import org.sopt.global.config.exception.BusinessException;
+import org.sopt.global.config.exception.constant.ExceptionCode;
+
+public class UserNotFoundException extends BusinessException {
+	public UserNotFoundException() {
+		super(ExceptionCode.USER_NOT_FOUND);
+	}
+}

--- a/src/main/java/org/sopt/global/config/cache/CacheConfig.java
+++ b/src/main/java/org/sopt/global/config/cache/CacheConfig.java
@@ -1,0 +1,16 @@
+package org.sopt.global.config.cache;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+	@Bean
+	public CacheManager cacheManager() {
+		return new ConcurrentMapCacheManager("userPostTimeCache");
+	}
+}

--- a/src/main/java/org/sopt/global/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/config/exception/GlobalExceptionHandler.java
@@ -1,17 +1,22 @@
 package org.sopt.global.config.exception;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sopt.global.config.exception.constant.ExceptionCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+	private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
 	@ExceptionHandler(BusinessException.class)
 	public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException ex) {
@@ -39,8 +44,9 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ExceptionResponse> handleException() {
+	public ResponseEntity<ExceptionResponse> handleException(Exception e) {
 		ExceptionResponse exceptionResponse = ExceptionResponse.of(ExceptionCode.INTERNAL_SERVER_ERROR);
+		log.info(e.getMessage());
 		return new ResponseEntity<>(exceptionResponse, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
@@ -58,5 +64,18 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ExceptionResponse.of(ExceptionCode.INTERNAL_SERVER_ERROR));
+	}
+
+	@ExceptionHandler(MissingRequestHeaderException.class)
+	public ResponseEntity<ExceptionResponse> handleMissingHeaderException(MissingRequestHeaderException e) {
+
+		if (e.getHeaderName().equals("userId")) {
+			ExceptionResponse response = ExceptionResponse.of(ExceptionCode.EMPTY_USER_ID);
+			return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+		}
+
+		log.info("필드 누락: " + e.getHeaderName());
+		ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INVALID_INPUT_VALUE);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 }

--- a/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
+++ b/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
@@ -18,6 +18,8 @@ public enum ExceptionCode {
 	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "c40023", "올바르지 않은 이메일 형식입니다."),
 	EMPTY_USER_ID(HttpStatus.BAD_REQUEST, "c40013", "유저ID는 필수입니다."),
 
+	INVALID_TAG(HttpStatus.BAD_REQUEST, "c40024", "올바르지 않은 태그입니다."),
+
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "대상이 존재하지 않습니다"),

--- a/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
+++ b/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
@@ -22,6 +22,8 @@ public enum ExceptionCode {
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "대상이 존재하지 않습니다"),
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "c4041", "게시글이 존재하지 않습니다."),
 
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "c4042", "사용자가 존재하지 않습니다."),
+
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "c4050", "잘못된 HTTP method 요청입니다."),
 
 	//409

--- a/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
+++ b/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
@@ -20,6 +20,9 @@ public enum ExceptionCode {
 
 	INVALID_TAG(HttpStatus.BAD_REQUEST, "c40024", "올바르지 않은 태그입니다."),
 
+	//403
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "c4031", "작성자만 게시물을 변경할 수 있습니다."),
+
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "대상이 존재하지 않습니다"),

--- a/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
+++ b/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
@@ -6,10 +6,16 @@ public enum ExceptionCode {
 
 	//400
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "c4000", "잘못된 요청입니다."),
+
 	EMPTY_TITLE(HttpStatus.BAD_REQUEST, "c40010", "제목이 비어있습니다"),
 	TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "c40020", "제목은 30글자를 넘을 수 없습니다."),
+
 	EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "c40011", "내용이 비어있습니다"),
 	CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "c40021", "내용은 1000자를 넘을 수 없습니다."),
+
+	EMPTY_NAME(HttpStatus.BAD_REQUEST, "c40012", "이름이 비어있습니다"),
+	NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "c40022", "이름은 7자를 넘을 수 없습니다."),
+	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "c40023", "올바르지 않은 이메일 형식입니다."),
 
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),

--- a/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
+++ b/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
@@ -8,6 +8,8 @@ public enum ExceptionCode {
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "c4000", "잘못된 요청입니다."),
 	EMPTY_TITLE(HttpStatus.BAD_REQUEST, "c40010", "제목이 비어있습니다"),
 	TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "c40020", "제목은 30글자를 넘을 수 없습니다."),
+	EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "c40011", "내용이 비어있습니다"),
+	CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "c40021", "내용은 1000자를 넘을 수 없습니다."),
 
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),

--- a/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
+++ b/src/main/java/org/sopt/global/config/exception/constant/ExceptionCode.java
@@ -16,6 +16,7 @@ public enum ExceptionCode {
 	EMPTY_NAME(HttpStatus.BAD_REQUEST, "c40012", "이름이 비어있습니다"),
 	NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "c40022", "이름은 7자를 넘을 수 없습니다."),
 	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "c40023", "올바르지 않은 이메일 형식입니다."),
+	EMPTY_USER_ID(HttpStatus.BAD_REQUEST, "c40013", "유저ID는 필수입니다."),
 
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -21,4 +21,6 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
 	boolean existsByTitle_Content(String title);
 
 	Optional<Post> findTopByOrderByCreatedAtDesc();
+
+	List<Post> findAllOrderByOrderByCreatedAtDesc();
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -6,14 +6,18 @@ import java.util.Optional;
 import org.sopt.domain.Post;
 import org.sopt.domain.constant.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Integer> {
-	List<Post> findByTagAndTitle_ContentContainingOrTagAndUser_NameContaining(Tag tag, String titleKeyword, Tag tag2,
-		String nameKeyword);
-
-	List<Post> findByTitle_ContentContainingOrUser_NameContaining(String titleKeyword, String nameKeyword);
-
-	List<Post> findAllByTag(Tag tag);
+	// PostRepository 인터페이스에 추가
+	@Query("SELECT p FROM Post p WHERE " +
+		"(:tag IS NULL OR p.tag = :tag) AND " +
+		"(:keyword IS NULL OR LOWER(p.title.content) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+		"LOWER(p.user.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+	List<Post> findByKeywordAndTagDynamically(
+		@Param("keyword") String keyword,
+		@Param("tag") Tag tag);
 
 	boolean existsByTitle_Content(String title);
 

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -13,7 +13,8 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
 	@Query("SELECT p FROM Post p WHERE " +
 		"(:tag IS NULL OR p.tag = :tag) AND " +
 		"(:keyword IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
-		"LOWER(p.user.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+		"LOWER(p.user.name) LIKE LOWER(CONCAT('%', :keyword, '%')))" +
+		"ORDER BY p.createdAt DESC ")
 	List<Post> findByKeywordAndTagDynamically(
 		@Param("keyword") String keyword,
 		@Param("tag") Tag tag);

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,7 +1,6 @@
 package org.sopt.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.sopt.domain.Post;
 import org.sopt.domain.constant.Tag;
@@ -20,8 +19,6 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
 		@Param("tag") Tag tag);
 
 	boolean existsByTitle_Content(String title);
-
-	Optional<Post> findTopByOrderByCreatedAtDesc();
 
 	List<Post> findAllOrderByOrderByCreatedAtDesc();
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -4,10 +4,16 @@ import java.util.List;
 import java.util.Optional;
 
 import org.sopt.domain.Post;
+import org.sopt.domain.constant.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Integer> {
-	List<Post> findByTitle_ContentContaining(String keyword);
+	List<Post> findByTagAndTitle_ContentContainingOrTagAndUser_NameContaining(Tag tag, String titleKeyword, Tag tag2,
+		String nameKeyword);
+
+	List<Post> findByTitle_ContentContainingOrUser_NameContaining(String titleKeyword, String nameKeyword);
+
+	List<Post> findAllByTag(Tag tag);
 
 	boolean existsByTitle_Content(String title);
 

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -10,10 +10,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Integer> {
-	// PostRepository 인터페이스에 추가
 	@Query("SELECT p FROM Post p WHERE " +
 		"(:tag IS NULL OR p.tag = :tag) AND " +
-		"(:keyword IS NULL OR LOWER(p.title.content) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+		"(:keyword IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
 		"LOWER(p.user.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
 	List<Post> findByKeywordAndTagDynamically(
 		@Param("keyword") String keyword,

--- a/src/main/java/org/sopt/repository/UserRepository.java
+++ b/src/main/java/org/sopt/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.repository;
+
+import org.sopt.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+}

--- a/src/main/java/org/sopt/service/PostCacheService.java
+++ b/src/main/java/org/sopt/service/PostCacheService.java
@@ -1,0 +1,49 @@
+package org.sopt.service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostCacheService {
+	private static final String USER_POST_TIME_CACHE = "userPostTimeCache";
+
+	private final CacheManager cacheManager;
+
+	public PostCacheService(CacheManager cacheManager) {
+		this.cacheManager = cacheManager;
+	}
+
+	public Optional<LocalDateTime> getUserLastPostTime(int userId, Duration coolTime) {
+		Cache cache = cacheManager.getCache(USER_POST_TIME_CACHE);
+		if (cache == null) {
+			return Optional.empty();
+		}
+
+		Cache.ValueWrapper wrapper = cache.get(userId);
+		if (wrapper == null) {
+			return Optional.empty();
+		}
+
+		LocalDateTime lastPostTime = (LocalDateTime)wrapper.get();
+		Duration timeSinceLastPost = Duration.between(lastPostTime, LocalDateTime.now());
+
+		if (timeSinceLastPost.compareTo(coolTime) >= 0) {
+			cache.evict(userId);
+			return Optional.empty();
+		}
+
+		return Optional.of(lastPostTime);
+	}
+
+	public void updateUserLastPostTime(int userId, LocalDateTime time) {
+		Cache cache = cacheManager.getCache(USER_POST_TIME_CACHE);
+		if (cache != null) {
+			cache.put(userId, time);
+		}
+	}
+}

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -64,14 +64,14 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
-	public PostDetailResponse getPostById(int id) {
-		Post post = postRepository.findById(id).orElseThrow(PostNotFoundException::new);
+	public PostDetailResponse getPostById(int postId) {
+		Post post = findPostById(postId);
 		return PostDetailResponse.from(post);
 	}
 
 	@Transactional
-	public void deletePostById(int id) {
-		Post post = postRepository.findById(id).orElseThrow(PostNotFoundException::new);
+	public void deletePostById(int postId) {
+		Post post = findPostById(postId);
 		postRepository.delete(post);
 	}
 
@@ -81,7 +81,7 @@ public class PostService {
 
 		validatePostTitle(title);
 
-		Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+		Post post = findPostById(postId);
 		post.updatePost(title, request.content());
 	}
 
@@ -97,6 +97,10 @@ public class PostService {
 	private User findUserById(int userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(UserNotFoundException::new);
+	}
+
+	private Post findPostById(int postId) {
+		return postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
 	}
 
 	private void validatePostTitle(String title) {

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -41,10 +41,9 @@ public class PostService {
 	@Transactional
 	public PostResponse createPost(int userId, PostCreateRequest postCreateRequest) {
 		User user = findUserById(userId);
+		checkUserCooldown(userId);
 
 		validatePostTitle(postCreateRequest.title());
-
-		checkUserCooldown(userId);
 
 		Post post = buildPostFrom(postCreateRequest, user);
 		Post savedPost = postRepository.save(post);

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -56,7 +56,7 @@ public class PostService {
 
 	@Transactional(readOnly = true)
 	public List<PostResponse> getAllPost() {
-		List<Post> posts = postRepository.findAll();
+		List<Post> posts = postRepository.findAllOrderByOrderByCreatedAtDesc();
 
 		return posts.stream()
 			.map(PostResponse::from)

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -70,7 +70,7 @@ public class PostService {
 
 		verifyTitleNotDuplicated(title);
 		Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
-		post.updatePost(title);
+		post.updatePost(title, request.content());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -87,18 +87,7 @@ public class PostService {
 
 	@Transactional(readOnly = true)
 	public List<PostResponse> searchPost(String keyword, Tag tag) {
-		List<Post> posts;
-
-		if (keyword == null && tag == null) {
-			posts = postRepository.findAll();
-		} else if (keyword == null) {
-			posts = postRepository.findAllByTag(tag);
-		} else if (tag == null) {
-			posts = postRepository.findByTitle_ContentContainingOrUser_NameContaining(keyword, keyword);
-		} else {
-			posts = postRepository.findByTagAndTitle_ContentContainingOrTagAndUser_NameContaining(
-				tag, keyword, tag, keyword);
-		}
+		List<Post> posts = postRepository.findByKeywordAndTagDynamically(keyword, tag);
 
 		return posts.stream()
 			.map(PostResponse::from)

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.sopt.domain.Content;
 import org.sopt.domain.Post;
 import org.sopt.domain.Title;
+import org.sopt.domain.constant.Tag;
 import org.sopt.dto.PostCreateRequest;
 import org.sopt.dto.PostResponse;
 import org.sopt.dto.PostUpdateRequest;
@@ -36,8 +37,9 @@ public class PostService {
 
 		Title validTitle = new Title(title);
 		Content content = new Content(postCreateRequest.content());
+		Tag tag = postCreateRequest.tag();
 
-		Post post = Post.create(validTitle, content);
+		Post post = Post.create(validTitle, content, tag);
 		Post savedPost = postRepository.save(post);
 
 		return PostResponse.from(savedPost);

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -86,8 +86,19 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<PostResponse> searchPost(String keyword) {
-		List<Post> posts = postRepository.findByTitle_ContentContaining(keyword);
+	public List<PostResponse> searchPost(String keyword, Tag tag) {
+		List<Post> posts;
+
+		if (keyword == null && tag == null) {
+			posts = postRepository.findAll();
+		} else if (keyword == null) {
+			posts = postRepository.findAllByTag(tag);
+		} else if (tag == null) {
+			posts = postRepository.findByTitle_ContentContainingOrUser_NameContaining(keyword, keyword);
+		} else {
+			posts = postRepository.findByTagAndTitle_ContentContainingOrTagAndUser_NameContaining(
+				tag, keyword, tag, keyword);
+		}
 
 		return posts.stream()
 			.map(PostResponse::from)

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.sopt.domain.Content;
 import org.sopt.domain.Post;
 import org.sopt.domain.Title;
 import org.sopt.dto.PostCreateRequest;
@@ -34,8 +35,9 @@ public class PostService {
 		checkLastPostTime();
 
 		Title validTitle = new Title(title);
+		Content content = new Content(postCreateRequest.content());
 
-		Post post = Post.create(validTitle);
+		Post post = Post.create(validTitle, content);
 		Post savedPost = postRepository.save(post);
 
 		return PostResponse.from(savedPost);

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -11,6 +11,7 @@ import org.sopt.domain.Title;
 import org.sopt.domain.User;
 import org.sopt.domain.constant.Tag;
 import org.sopt.dto.PostCreateRequest;
+import org.sopt.dto.PostDetailResponse;
 import org.sopt.dto.PostResponse;
 import org.sopt.dto.PostUpdateRequest;
 import org.sopt.exception.PostNotFoundException;
@@ -63,9 +64,9 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
-	public PostResponse getPostById(int id) {
+	public PostDetailResponse getPostById(int id) {
 		Post post = postRepository.findById(id).orElseThrow(PostNotFoundException::new);
-		return PostResponse.from(post);
+		return PostDetailResponse.from(post);
 	}
 
 	@Transactional

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -1,0 +1,23 @@
+package org.sopt.service;
+
+import org.sopt.domain.User;
+import org.sopt.dto.UserCreateRequest;
+import org.sopt.dto.UserResponse;
+import org.sopt.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	public UserResponse createUser(UserCreateRequest userCreateRequest) {
+		User user = User.createUser(userCreateRequest.name(), userCreateRequest.email());
+		User createdUser = userRepository.save(user);
+
+		return UserResponse.of(createdUser.getName(), createdUser.getEmail());
+	}
+}

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -18,6 +18,6 @@ public class UserService {
 		User user = User.create(userCreateRequest.name(), userCreateRequest.email());
 		User createdUser = userRepository.save(user);
 
-		return UserResponse.of(createdUser.getName(), createdUser.getEmail());
+		return UserResponse.of(createdUser.getId(), createdUser.getName(), createdUser.getEmail());
 	}
 }

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -15,7 +15,7 @@ public class UserService {
 	}
 
 	public UserResponse createUser(UserCreateRequest userCreateRequest) {
-		User user = User.createUser(userCreateRequest.name(), userCreateRequest.email());
+		User user = User.create(userCreateRequest.name(), userCreateRequest.email());
 		User createdUser = userRepository.save(user);
 
 		return UserResponse.of(createdUser.getName(), createdUser.getEmail());

--- a/src/main/java/org/sopt/util/ContentFormatValidateUtil.java
+++ b/src/main/java/org/sopt/util/ContentFormatValidateUtil.java
@@ -1,0 +1,21 @@
+package org.sopt.util;
+
+import static org.sopt.util.StringLengthUtil.*;
+
+import org.sopt.exception.ContentEmptyException;
+import org.sopt.exception.ContentLengthException;
+
+public class ContentFormatValidateUtil {
+	private static final int CONTENT_MAX_LENGTH = 1000;
+
+	public static void validateContentFormat(String value) {
+		if (value == null || value.isBlank()) {
+			throw new ContentEmptyException();
+		}
+
+		int length = getLength(value);
+		if (length > CONTENT_MAX_LENGTH) {
+			throw new ContentLengthException();
+		}
+	}
+}

--- a/src/main/java/org/sopt/util/EmailValidator.java
+++ b/src/main/java/org/sopt/util/EmailValidator.java
@@ -8,7 +8,7 @@ import org.sopt.exception.NameLengthException;
 
 public class EmailValidator {
 	private static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
-	private static final int USER_NAME_MAX = 7;
+	private static final int USER_NAME_MAX = 10;
 
 	public static void validate(String name, String email) {
 		if (email == null || email.isBlank()) {

--- a/src/main/java/org/sopt/util/EmailValidator.java
+++ b/src/main/java/org/sopt/util/EmailValidator.java
@@ -1,0 +1,29 @@
+package org.sopt.util;
+
+import static org.sopt.util.StringLengthUtil.*;
+
+import org.sopt.exception.InvalidEmailFormatException;
+import org.sopt.exception.NameEmptyException;
+import org.sopt.exception.NameLengthException;
+
+public class EmailValidator {
+	private static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+	private static final int USER_NAME_MAX = 7;
+
+	public static void validate(String name, String email) {
+		if (email == null || email.isBlank()) {
+			throw new NameEmptyException();
+		}
+
+		if (!email.matches(EMAIL_REGEX)) {
+			throw new InvalidEmailFormatException();
+		}
+
+		int length = getLength(name);
+
+		if (length > USER_NAME_MAX) {
+			throw new NameLengthException();
+		}
+	}
+}
+

--- a/src/main/java/org/sopt/util/TitleFormatValidateUtil.java
+++ b/src/main/java/org/sopt/util/TitleFormatValidateUtil.java
@@ -6,7 +6,7 @@ import org.sopt.exception.TitleEmptyException;
 import org.sopt.exception.TitleLengthException;
 
 public class TitleFormatValidateUtil {
-	private static final int MAX_LENGTH = 30;
+	private static final int TITLE_MAX_LENGTH = 30;
 
 	public static void validateTitleFormat(String value) {
 		if (value == null || value.isBlank()) {
@@ -14,7 +14,7 @@ public class TitleFormatValidateUtil {
 		}
 
 		int length = getLength(value);
-		if (length > MAX_LENGTH) {
+		if (length > TITLE_MAX_LENGTH) {
 			throw new TitleLengthException();
 		}
 	}

--- a/src/main/java/org/sopt/util/TitleFormatValidateUtil.java
+++ b/src/main/java/org/sopt/util/TitleFormatValidateUtil.java
@@ -8,7 +8,7 @@ import org.sopt.exception.TitleLengthException;
 public class TitleFormatValidateUtil {
 	private static final int MAX_LENGTH = 30;
 
-	public static void validate(String value) {
+	public static void validateTitleFormat(String value) {
 		if (value == null || value.isBlank()) {
 			throw new TitleEmptyException();
 		}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,4 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
+  jpa.open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,16 +1,14 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
+    url: "jdbc:mysql://localhost:3306/community"
+    username: ${username}
+    password: ${password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
-    show-sql: true
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        show_sql: true


### PR DESCRIPTION
## 📌 구현 목록

### 필수과제
- [x] User 추가
- [x] 게시글 내용 추가
- [x] 게시글 내용 검증 추가
- [x] 아래 API 구현
- 게시글 생성 API
- 게시글 전체 조회 API (최신 순으로 조회 / 제목과 게시글 작성자만 보일 수 있도록 해주세요.)
- 게시글 상세 조회 API (제목과 내용, 게시글 작성자가 모두 보이도록 해주세요.)
- 게시글 수정 API 
- 게시글 삭제 API

### 선택과제

**제약 조건 검증 구현**
- [x] 게시글의 제목은 30자를 넘지 않게 해주세요.
- [x] 게시글의 내용은 1000자를 넘지 않게 해주세요.
- [x] 유저의 이름(닉네임)은 10자를 넘지 않게 해주세요. 
- [x] 게시글의 제목은 중복되지 않게 해주세요.
- [x] 전체 게시글 목록에서 같은 제목을 가진 게시글이 없어야 합니다.

**검색기능 추가**
- [x] 사용자는 게시글 제목 혹은 작성자 를 기준으로 검색할 수 있습니다. 

**태그 추가**
- [x] 태그 기반 검색기능 추가



## 📌 구현 상세 및 고민

<details>
<summary>✅ 예외처리 </summary>
<div>

### 🤔 어떻게 구현하였나요?
1. 헤더를 입력받는 경우 입력헤더가 없을 때 원하는 예외로 던져주도록 구현했습니다. 
2. 입력을 검증할 때 controller보다는 요청 dto가 생성되는 시점에 예외를 던지도록 구현했습니다. 

### 🤔 이런 고민이 있었어요!
1. 검증의 위치를 어디로 해야하는가?
2. 입력에 대한 예외 검증은 어디로 해야하는가?

### 💭 내가 내린 결론
제 생각은 입력시 빈 값을 받았을 때 예외를 던지는 편이 더 효율적이라고 생각했습니다.
그 이유는 잘못된 입력이 controller를 넘어 service 레이어 까지 타게 하는 것이 효율적이지 못하다고 생각했기 때문입니다.
때문에 spring validation의 `@NotBlank` 처럼 입력을 받았을 때 선제적으로 감지하여 예외를 미리 던지도록 구현했습니다.
예외 핸들링은 AOP나 Argument Resolver를 구현하는 생각도 고려했으나, 관심사를 하나로 모으는 것이 관리하기 좋다고 생각해 
GlobalExceptionHandler에서 예외를 잡도록 구현했습니다.

**구현 상세**

`@RequestHeader` 가 빈 값이 존재하는 경우 `MissingRequestHeaderException`가 발생합니다.
이를 GlobalExceptionHandler에서 감지하여 커스텀예외를 던지도록 구현했습니다.
또한 json을 dto로 변환하면서 발생하는 예외인 `HttpMessageNotReadableException` 도 지난 주차 구현에서 `GlobalExceptionHandler` 로 예외를 던지도록 구현했습니다.
</div>
</details>


<details>
<summary>✅  올바르지 않은 Enum 입력 검증</summary>
<div>

### 🤔 어떻게 구현하였나요?
Tag에 `@JsonCreator` 를 이용하여 올바르지 않은 Enum이면 예외를 던지도록 구현했습니다.

### 🤔 이런 고민이 있었어요!
enum을 String으로 받고 검증을 dto안에서 진행하는 방법과 dto로 변환하는 과정에서 감지하는 방법중에 고민했습니다(JsonCreator)

### 💭 내가 내린 결론
`@JsonCreator`를 이용한 방식을 선택했습니다. 이유는 다음과 같아요
Tag라는 타입의 검증은 Tag에서 진행하여 불필요한 검증 클래스를 늘리게 할 수 있기 때문입니다.
</div>
</details>

<details>
<summary>✅  검색기능 구현</summary>
<div>

### 🤔 어떻게 구현하였나요?
keyword와 tag를 파라미터로 받아 tag를 기준으로 keword에 포함되는 제목, 유저이름을 찾아 List로 반환하게 구현했습니다.
tag와 keyword 둘 다 nullable하게 구현하여 다양한 옵션에도 대응할 수 있게 구현했습니다.

### 🤔 이런 고민이 있었어요!
명시적인 분기 처리와 동적쿼리 중 어느것이 좋을지 고민했습니다.
분기처리를 할 경우 Repository에 메서드를 세 개 이상 구현해야 했고, 동적쿼리는 쿼리 자체가 너무 길어져 가독성이 좋지 않아지는 트레이드 오프가 있었습니다.

### 💭 내가 내린 결론
동적 쿼리를 이용하여 구현했습니다. 이유는 다음과 같아요
동적쿼리는 디버깅이 조금 어려우나, 서비스 코드가 복잡해지는 것을 막습니다, 추후 변경이 필요할 경우 완전 새로운 메서드를 만들어서 테스트를 해볼 수 있는 것도 장점이라고 생각했습니다.

```java
@Query("SELECT p FROM Post p WHERE " +
		"(:tag IS NULL OR p.tag = :tag) AND " +
		"(:keyword IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
		"LOWER(p.user.name) LIKE LOWER(CONCAT('%', :keyword, '%')))" +
		"ORDER BY p.createdAt DESC ")
	List<Post> findByKeywordAndTagDynamically(
		@Param("keyword") String keyword,
		@Param("tag") Tag tag);
```
조금 쿼리가 복잡하지만, 이 경우라면 새로운 요구사항이 나왔을때 완전 다른 메서드를 만들어 새롭게 구현할 수 있을 것 같아요 

```java
if (keyword == null && tag == null) {
			posts = postRepository.findAll();
		} else if (keyword == null) {
			posts = postRepository.findAllByTag(tag);
		} else if (tag == null) {
			posts = postRepository.findByTitle_ContentContainingOrUser_NameContaining(keyword, keyword);
		} else {
			posts = postRepository.findByTagAndTitle_ContentContainingOrTagAndUser_NameContaining(
				tag, keyword, tag, keyword);
		}
```
이런 복잡한 분기문 보다는 가독성면에서도 차라리 낫다는게 저의 생각입니다... 

이외에 해결방법이 있다면 의견 부탁드립니다~!!

</div>
</details>

<details>
<summary>✅ 3분 대기 구현 </summary>
<div>

### 🤔 어떻게 구현하였나요?
유저마다 다음 글을 쓰기전에 3분동안 대기해야하는 기능을 구현했습니다.
이 기능은 명시도 되어있지 않고, 1주차에 있던 내용을 계속 업그레이드 하는 중입니다. 

### 🤔 이런 고민이 있었어요!
이전에는 유저가 한명이라고 생각했기 때문에 db에 있는 게시물 전체에서 가장 최근 게시물과 현재시간을 비교하는 방식으로 구현했습니다.
하지만 유저가 여러명이라면 매번 유저를 이용해서 게시물과 함께 비교하여 검증해야 합니다. 이 방식은 db에 부하가 발생하기 쉬운 방식이라고 생각하여 해결 할 방법을 고민했습니다.

### 💭 내가 내린 결론
캐시를 이용했습니다. 
글을 작성할때 캐시에서 userId와 시간을 가져오고 현재시간과 비교하여 3분이 지났는지 검증합니다.
만약 캐시에 userId가 없는 경우 글을 작성하고 다시 캐시에 유저를 넣습니다
캐시에 해당 유저가 있는경우 시간을 비교하여 3분이 지난 상태라면 캐시에서 유저를 지우고 글을 작성합니다.

캐시이기 때문에 좀 더 빠른 조회가 가능하고 DB 부하는 최소화 할 수 있는 방식이라고 생각하고 구현했으나, 혹시 성능적으로나 구현방식에서 오버헤드가 발생하는 부분이 있다면 함께 고민해보고 싶어요

</div>
</details>


## 📌 키워드 과제 

- ERD는 무엇이고, 어떻게 작성하나요? (ERD Cloud 같은 ERD 작성 툴 사용해보기)
    
    ERD는 데이터베이스 구조를 시각적으로 표현한 다이어그램이다.
    
     데이터베이스에 저장될 데이터들의 종류와 특징 그리고 이 데이터들 간에 어떤 관계가 있는지를 그림으로 나타낸다.
    
    작성하는 방법은 다음과 같다
    
    - **개체(Entity):** 데이터베이스에 저장하려는 현실 세계의 객체 또는 개념을 의미한다. 이번 과제 같은 경우, 게시물, 유저가 개체가 될 수 있다. 일반적으로 사각형으로 표현한다.
    - **속성(Attribute):** 개체가 가지는 특징이나 정보를 나타낸다. 예를 들어, '학생' 개체의 속성은 제목, 이름, 내용, 태그 등이 될 수 있다. 일반적으로 타원형으로 표현하거나, 개체 사각형 안에 목록으로 표시한다.
        - **기본 키(Primary Key):** 개체를 고유하게 식별할 수 있는 속성이다. (예: 게시물 id)
        - **외래 키(Foreign Key):** 다른 개체의 기본 키를 참조하여 개체 간의 관계를 연결하는 속성이다.
    
    이렇게 정해진 데이터베이스 개체들은 서로 관계를 가지게 되는데 대표적으로 
    
    - **1:1 (일대일):** 한 개체가 다른 한 개체와 관계를 맺음
    - **1:N (일대다):** 한 개체가 다른 여러 개체와 관계를 맺지만, 다른 개체는 한 개체와만 관계를 맺는다. (이번 과제의 경우 유저 - 게시물)
    - **N:M (다대다):** 여러 개체가 다른 여러 개체와 관계를 맺는다.

<img width="1005" alt="스크린샷 2025-05-02 오후 4 37 22" src="https://github.com/user-attachments/assets/5b33c0f3-15ab-4124-a264-cbd7792cc8c5" />

- `@ManyToOne`, `@OneToMany` 어노테이션에 대해 공부해보기
    
    ## `@ManyToOne` 어노테이션
    
    ### 동작 원리
    
    - 엔티티 간 다대일(N:1) 관계를 매핑하기 위해 사용된다.
    - 외래 키가 “다” 쪽 테이블에 생성되며, 자식 엔티티가 부모 엔티티의 식별자를 참조한다.
    - 기본 페치 전략은 즉시 로딩이다.
    
    ### 사용 시점
    
    - 여러 자식 엔티티가 하나의 부모 엔티티를 참조할 때 지정한다.
    - 예를 들어, `OrderItem` 엔티티가 `Order` 엔티티를 참조하는 경우에 사용한다.
    
    ### 주의 사항
    
    - 즉시 로딩 특성으로 인해 불필요한 조인이 발생하여 성능 저하를 유발할 수 있다.
    - 필요 시 `fetch = FetchType.LAZY`로 변경하여 지연 로딩으로 전환하는 것이 좋다.
    - 양방향 연관관계에서는 `@ManyToOne` 쪽이 연관관계의 주인(owner)이므로, 이 쪽에만 외래 키 설정을 두어야 한다.
    
    ## `@OneToMany` 어노테이션
    
    ### 동작 원리
    
    - 엔티티 간 일대다(1:N) 관계를 매핑하기 위해 사용된다.
    - `mappedBy` 속성으로 반대쪽 `@ManyToOne` 필드를 지정해야 한다.
    - 기본 페치 전략은 지연 로딩(LAZY)으로, 실제로 접근할 때 데이터베이스에서 조회된다.
    
    ### 사용 시점
    
    - 하나의 부모 엔티티가 여러 자식 엔티티 리스트를 보유해야 할 때 지정한다.
    - 예를 들어, `Order` 엔티티가 여러 `OrderItem` 엔티티를 리스트로 관리할 때 사용한다.
    
    ### 주의 사항
    
    - 양방향 관계에서 `mappedBy`를 잘못 지정하면 불필요한 조인 테이블이 생성될 수 있다.
    - 컬렉션 타입 필드는 `equals()`/`hashCode()` 구현 시 주의해야 하며, 프록시 타입 비교 문제가 발생할 수 있다.
    - 값 변경 시 영속성 전파(cascade)나 고아 객체 제거(orphanRemoval)를 설정하지 않으면 데이터 불일치가 생길 수 있다.
    - 기본 설정이 `FetchType.LAZY`이므로 트랜잭션 범위 밖에서 접근하면 `LazyInitializationException`이 발생할 수 있다.
- `ManyToOne` 은 N+1 문제 (쿼리가 하나 더 발생하는 문제) 가 발생할 수 있다 (성능 저하)
- 만약 `ManyToOne` , `OneToMany`  를 함께 사용하여 양방향 매핑을 사용 할 경우 순환 참조 문제도 발생할 수 있다.
특히 toString이나 equals 같은 필드를 참조하는 메서드가 사용될 때 발생한다
이 경우 해당 메서드 들을 오버라이딩해서 해결하거나, Jackson 어노테이션 등을 사용하여 해결 할 수 있다.

- `@OneToMany` 의 `cascade` 옵션과 `fetch` 옵션 공부하기

cascade란 부모엔티티의 변화를 자식에 전파하기 위한 속성이다. 부모와 생명주기를 함께 관리하기 위해 사용할 수 있다. 만약 부모가 삭제된다면, 자식도 함께 삭제하는 `CascadeType.REMOVE` 를 사용하면 유저가 삭제될 때 자식도 함께 삭제할 수 있다.

- `CascadeType.PERSIST`
    - 부모를 저장(PERSIST)할 때, 연관된 자식도 함께 저장한다.
- `CascadeType.MERGE`
    - 부모를 병합(MERGE)할 때, 자식도 함께 병합한다.
- `CascadeType.REMOVE`
    - 부모를 삭제(REMOVE)할 때, 자식도 함께 삭제한다.
- `CascadeType.REFRESH`
    - 부모를 새로 고침(REFRESH)할 때, 자식도 함께 새로 고침한다.
- `CascadeType.DETACH`
    - 부모를 분리(DETACH)할 때, 자식도 함께 분리한다.
- `CascadeType.ALL`
    - 위 모든 옵션을 한꺼번에 적용한다.

